### PR TITLE
fix(scrape): follow the sdv-py event_officials -> game_officials rename

### DIFF
--- a/python/scrape_wbb_officials.py
+++ b/python/scrape_wbb_officials.py
@@ -1,4 +1,3 @@
-
 """Scrape ESPN women's-college-basketball per-game officials.
 
 Output: ``wbb/officials/json/{game_id}.json`` -- raw ESPN response. The
@@ -10,10 +9,10 @@ Game ids are sourced from the season's schedule parquet
 is missing, falls back to a fresh ``sdv.wbb.espn_wbb_schedule`` call.
 
 Requirements:
-    Depends on the ``espn_wbb_event_officials`` helper added to
-    ``sportsdataverse-py`` (sportsdataverse/wbb/wbb_event_officials.py).
-    The repo's ``requirements.txt`` should pin a version of sportsdataverse-py
-    that exports it; until that release lands, install sdv-py from source
+    Depends on the ``espn_wbb_game_officials`` helper in ``sportsdataverse-py``
+    (sportsdataverse/wbb/wbb_game_officials.py). The repo's
+    ``requirements.txt`` should pin a version of sportsdataverse-py that exports
+    it; until that release lands, install sdv-py from source
     (``pip install -e <path>/sdv-py``).
 """
 
@@ -32,10 +31,9 @@ import pandas as pd
 import sportsdataverse as sdv
 from tqdm import tqdm
 
-# The new module is not yet re-exported from ``sportsdataverse.wbb``, so we
-# import the function directly from its module to avoid relying on the
-# top-level package surface.
-from sportsdataverse.wbb.wbb_event_officials import espn_wbb_event_officials
+# The module is not re-exported from ``sportsdataverse.wbb``, so we import the
+# function directly from its module to avoid relying on the top-level surface.
+from sportsdataverse.wbb.wbb_game_officials import espn_wbb_game_officials
 
 
 logging.basicConfig(
@@ -65,9 +63,7 @@ def fetch_game_ids_for_season(season: int) -> list[int]:
         ids = pd.to_numeric(df["game_id"], errors="coerce").dropna().astype(int)
         return sorted(ids.unique().tolist())
 
-    logger.warning(
-        f"No schedule parquet at {schedule_path}; falling back to espn_wbb_schedule()"
-    )
+    logger.warning(f"No schedule parquet at {schedule_path}; falling back to espn_wbb_schedule()")
     sched = sdv.wbb.espn_wbb_schedule(season=season, groups=50, num_retries=MAX_RETRIES)
     if hasattr(sched, "to_pandas"):
         sched = sched.to_pandas()
@@ -86,12 +82,7 @@ def download_officials_batch(
 ) -> None:
     threads = min(cores, max(1, len(game_ids)))
     with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
-        futs = {
-            executor.submit(
-                download_officials, gid, output_dir, rerun_existing
-            ): gid
-            for gid in game_ids
-        }
+        futs = {executor.submit(download_officials, gid, output_dir, rerun_existing): gid for gid in game_ids}
         for fut in tqdm(
             concurrent.futures.as_completed(futs),
             total=len(futs),
@@ -100,15 +91,14 @@ def download_officials_batch(
             fut.result()
 
 
-def download_officials(
-    game_id: int, output_dir: Path, rerun_existing: bool
-) -> str:
+def download_officials(game_id: int, output_dir: Path, rerun_existing: bool) -> str:
     out_path = Path(output_dir) / f"{game_id}.json"
     if out_path.exists() and not rerun_existing:
         return f"skip {game_id}"
     try:
-        raw: dict[str, Any] = espn_wbb_event_officials(
-            game_id=int(game_id), raw=True,
+        raw: dict[str, Any] = espn_wbb_game_officials(
+            game_id=int(game_id),
+            raw=True,
             num_retries=MAX_RETRIES,
         )
         with open(out_path, "w", encoding="utf-8") as f:
@@ -121,9 +111,7 @@ def download_officials(
         return f"err {game_id}: {e}"
 
 
-def scrape_season(
-    season: int, cores: int, rerun_existing: bool, base_output_dir: str
-) -> None:
+def scrape_season(season: int, cores: int, rerun_existing: bool, base_output_dir: str) -> None:
     output_dir = Path(base_output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     game_ids = fetch_game_ids_for_season(season)
@@ -132,13 +120,9 @@ def scrape_season(
         logger.info(f"No game ids for {season}; skipping")
         return
     t0 = time.time()
-    download_officials_batch(
-        season, game_ids, output_dir, rerun_existing, cores
-    )
+    download_officials_batch(season, game_ids, output_dir, rerun_existing, cores)
     t1 = time.time()
-    logger.info(
-        f"{(t1 - t0) / 60:.2f} minutes to download {len(game_ids)} officials payloads for {season}."
-    )
+    logger.info(f"{(t1 - t0) / 60:.2f} minutes to download {len(game_ids)} officials payloads for {season}.")
 
 
 def main() -> None:


### PR DESCRIPTION
`scrape_wbb_officials.py` has been **dead since sdv-py commit `b1a60fd0`** ("feat(espn)!: token-level athlete->player / **event->game** convention everywhere"), which renamed `wbb_event_officials.py` → `wbb_game_officials.py` and `espn_wbb_event_officials` → `espn_wbb_game_officials`. The scraper still imported the old name, so it aborts at import with `ModuleNotFoundError` before scraping a single game.

```
ModuleNotFoundError: No module named 'sportsdataverse.wbb.wbb_event_officials'
```

## Fix
Pure rename — module, function, and the two stale docstring references. The new signature is `(game_id, season=None, *, raw=False, **kwargs)`, so the existing `game_id=..., raw=True` (+ `num_retries`) call site needed no other change.

## Verified
Module imports cleanly, and a live `espn_wbb_game_officials(game_id=..., raw=True)` call returns a populated ESPN Core v2 payload (`count/pageIndex/pageSize/pageCount/items`).

Found by the Phase-C historical-backfill runner, which refused to mark the job done on the nonzero exit rather than reporting a green run over zero files.