### PR TITLE
fix(scrape)!: use the _v3 career endpoint, not core-v2 statistics

### DIFF
--- a/python/scrape_wbb_player_stats.py
+++ b/python/scrape_wbb_player_stats.py
@@ -30,7 +30,13 @@ from tqdm import tqdm
 
 # Imported direct from the module path because the new helpers are not yet
 # re-exported via sportsdataverse.wbb.__init__.
-from sportsdataverse.wbb.wbb_player_stats import espn_wbb_player_stats
+# _v3 == the site.web.api common/v3 .../athletes/{id}/stats CAREER endpoint,
+# which is what every file under wbb/player_season_stats/json/ is and what the
+# downstream parser reads (categories[].statistics[]). The unsuffixed
+# espn_wbb_player_stats is core-v2 /athletes/{id}/statistics -- a DIFFERENT
+# API returning $ref/season/athlete/splits. It imports fine and fails silently,
+# so do not "simplify" this import.
+from sportsdataverse.wbb import espn_wbb_player_stats_v3
 from sportsdataverse.dl_utils import download
 
 
@@ -99,10 +105,10 @@ def download_player_stats(season, athlete_id, output_dir, rerun_existing):
     if out_path.exists() and not rerun_existing:
         return f"skip {athlete_id}"
     try:
-        raw = espn_wbb_player_stats(
+        raw = espn_wbb_player_stats_v3(
             athlete_id=int(athlete_id),
             season=int(season),
-            raw=True,
+            return_parsed=False,
             num_retries=MAX_RETRIES,
         )
         with open(out_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
**`scrape_wbb_player_stats.py` has been writing the wrong payload — silently — since sdv-py's codegen redesign.**

## What happened
`espn_wbb_player_stats` *used to be* the site.web.api career endpoint. sdv-py repointed that **name** at a different API and preserved the original under a version suffix (`c7e5d22c`: *"version collisions instead of dropping (athlete_stats -> player_stats_v3)"*).

| function | endpoint | payload keys |
|---|---|---|
| `espn_wbb_player_stats` | core-v2 `/athletes/{id}/statistics` | `$ref`, `season`, `athlete`, `splits` |
| `espn_wbb_player_stats_v3` ✅ | site.web.api `common/v3 /athletes/{id}/stats` | `filters`, `teams`, `categories`, `glossary` |

**Nothing raised** — the name still resolved, so there was no `ImportError` to catch it (unlike the mbb/nba sister repos, where the old helper was deleted outright and they failed loudly). The scraper just quietly wrote core-v2 payloads the downstream parser can't read; it reads `categories[].statistics[]`. Every file already committed under `wbb/player_season_stats/json/` is the career shape.

## Fix
`espn_wbb_player_stats_v3(athlete_id=..., season=..., return_parsed=False)` — note `return_parsed=False`, not `raw=True`.

## Verified
Against a **tracked production file**: top-level keys identical (`filters/teams/categories/glossary`), `categories[]` names match (`averages/miscellaneous/totals`).

Sister PRs fix the same trap in hoopR-mbb-raw#2 / hoopR-nba-raw#2.