### PR TITLE
fix(ci): fail the daily run when a scraper dies instead of swallowing it

### DIFF
--- a/scripts/daily_wbb_scraper.sh
+++ b/scripts/daily_wbb_scraper.sh
@@ -20,6 +20,32 @@ done
 RESCRAPE=${RESCRAPE:-true}
 echo "Rescrape set to: $RESCRAPE"
 mkdir -p logs
+
+# Scraper failures used to be swallowed: each scraper ran bare, so a crash left
+# the loop running, the partial day got committed, and the job still exited 0.
+# Four scrapers sat dead for two sportsdataverse-py release cycles that way --
+# aborting at import on a renamed symbol, every day, silently green.
+#
+# run_scraper keeps that resilience (one dead scraper must not stop the others,
+# and whatever DID scrape should still be committed) but records the failure so
+# the run goes RED at the end and someone actually looks.
+#
+# NOTE: the scrapers run inside `{ ... } | tee`, and a pipe is a SUBSHELL -- a
+# counter variable incremented in there is discarded when it exits. That's why
+# failures go to a FILE. Do not "simplify" this to a FAILED=$((FAILED+1)) var.
+FAILLOG=$(mktemp "/tmp/wehoop_wbb_raw_failures.XXXXXX")
+trap 'rm -f "$FAILLOG"' EXIT
+
+run_scraper() {
+    local label="$1"; shift
+    "$@"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "!!! SCRAPER FAILED (rc=$rc): $label"
+        echo "$label rc=$rc" >> "$FAILLOG"
+    fi
+    return 0
+}
 for i in $(seq "${START_YEAR}" "${END_YEAR}")
 do
     LOGFILE="logs/wehoop_wbb_raw_logfile_${i}.log"
@@ -31,14 +57,14 @@ do
         git pull >> /dev/null
         git config --local user.email "action@github.com"
         git config --local user.name "Github Action"
-        python3 python/scrape_wbb_schedules.py    -s $i -e $i -r $RESCRAPE
-        python3 python/scrape_wbb_json.py         -s $i -e $i -r $RESCRAPE
-        python3 python/scrape_wbb_team_rosters.py -s $i -e $i -r $RESCRAPE
-        python3 python/scrape_wbb_player_stats.py -s $i -e $i -r $RESCRAPE
-        python3 python/scrape_wbb_team_stats.py   -s $i -e $i -r $RESCRAPE
-        python3 python/scrape_wbb_standings.py    -s $i -e $i -r $RESCRAPE
-        python3 python/scrape_wbb_game_rosters.py -s $i -e $i -r $RESCRAPE
-        python3 python/scrape_wbb_officials.py    -s $i -e $i -r $RESCRAPE
+        run_scraper schedules    python3 python/scrape_wbb_schedules.py    -s $i -e $i -r $RESCRAPE
+        run_scraper json         python3 python/scrape_wbb_json.py         -s $i -e $i -r $RESCRAPE
+        run_scraper team_rosters python3 python/scrape_wbb_team_rosters.py -s $i -e $i -r $RESCRAPE
+        run_scraper player_stats python3 python/scrape_wbb_player_stats.py -s $i -e $i -r $RESCRAPE
+        run_scraper team_stats   python3 python/scrape_wbb_team_stats.py   -s $i -e $i -r $RESCRAPE
+        run_scraper standings    python3 python/scrape_wbb_standings.py    -s $i -e $i -r $RESCRAPE
+        run_scraper game_rosters python3 python/scrape_wbb_game_rosters.py -s $i -e $i -r $RESCRAPE
+        run_scraper officials    python3 python/scrape_wbb_officials.py    -s $i -e $i -r $RESCRAPE
         git pull >> /dev/null
         git add wbb/* >> /dev/null
         git pull >> /dev/null
@@ -57,3 +83,17 @@ do
     git push >> /dev/null
     rm -f "$TMPLOG"
 done
+
+# Everything that could scrape has scraped, and every partial result is
+# committed and pushed -- only now do we decide the exit code. A dead scraper
+# must turn the run RED; a green run over silently-missing data is worse than
+# an obvious failure.
+if [ -s "$FAILLOG" ]; then
+    echo ""
+    echo "=================================================="
+    echo "SCRAPER FAILURES (data for these is NOT up to date)"
+    cat "$FAILLOG"
+    echo "=================================================="
+    exit 1
+fi
+echo "All scrapers OK."


### PR DESCRIPTION
The daily loop invoked each scraper bare, with **no `set -e` and no exit-code check**. A scraper that crashed at import produced a log line nobody read — the remaining scrapers ran, the partial day was committed and pushed, and **the job exited 0**. CI stayed green over data that had silently stopped updating.

**This is not hypothetical.** Four scrapers across these repos sat dead for *two* sportsdataverse-py release cycles — aborting at import on renamed/removed symbols, every single day — and nothing surfaced it. They were only found when a historical backfill happened to run them by hand.

## Fix
Wrap each of the 8 scrapers in `run_scraper`. It **preserves the existing resilience** — one dead scraper must not stop the others, and whatever *did* scrape still gets committed — but records the failure. After the loop, once every partial result is committed and pushed, a non-empty failure list prints the dead scrapers and **exits 1**.

```
!!! SCRAPER FAILED (rc=1): player_stats
...
==================================================
SCRAPER FAILURES (data for these is NOT up to date)
player_stats rc=1
==================================================
```

## Implementation note (the subtle part)
The scrapers run inside `{ ... } | tee`, and **a pipe is a subshell** — a counter variable incremented in there is discarded when it exits. Failures are recorded to a **file** for exactly that reason. Please don't "simplify" it to `FAILED=$((FAILED+1))`; there's a comment in the source saying so.

## Verified
A simulated crash mid-block logs the failure, lets the following scrapers run, escapes the subshell, and exits 1. No change to the load-bearing commit subject or the scrape order.

**Heads up:** this may turn currently-"green" runs red. That's the point — but it means the next failure is visible rather than silent.